### PR TITLE
#4 - Check if the Default Firebase app is already loaded

### DIFF
--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -13,7 +13,14 @@ import FirebaseAnalytics
 @objc(CapacitorFirebaseAnalytics)
 public class CapacitorFirebaseAnalytics: CAPPlugin {
 
-    var fbase = FirebaseApp.configure();
+    var fbase: FirebaseApp? = nil;
+    
+    public override func load() {
+        if (FirebaseApp.app() == nil) {
+            FirebaseApp.configure();
+            fbase = FirebaseApp.app()
+        }
+    }
     
     @objc func setScreenName(_ call: CAPPluginCall) {
         let screenName = call.getString("screenName");


### PR DESCRIPTION
Hi @philmerrell ,

This check is necessary to prevent conflites with Capacitor Firebase Auth, another Capacitor plugin to use with Firebase applications.

Please, see Issue #4 to more details.

Best regards,
Bernardo Baumblatt